### PR TITLE
feat: avro implicit for scala and examples of avro usage in request reply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           KAFKA_INTER_BROKER_LISTENER_NAME: BROKER
           KAFKA_BROKER_ID: "1"
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-          KAFKA_CREATE_TOPICS: "myTopic:1:1, test.t:1:1"
+          KAFKA_CREATE_TOPICS: "myTopic1:1:1, test.t1:1:1, myTopic2:1:1, test.t2:1:1, myTopic3:1:1, test.t3:1:1"
         ports:
           - '9092:9092'
           - '9093:9093'

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ public static Deserializer<AvroClass> de = (Deserializer) new KafkaAvroDeseriali
 To use avro messages as payload in key or value, you must define serde for your class:
 
 ```kotlin
-    val ser = KafkaAvroSerializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Serializer<AvroClass>
+val ser = KafkaAvroSerializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Serializer<AvroClass>
 val de = KafkaAvroDeserializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Deserializer<AvroClass>
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,3 +67,60 @@ To run you should create scala object in root project directory and type `sbt ru
 ### Example download avro-schema
 
 Example [here](https://github.com/TinkoffCreditSystems/gatling-kafka-plugin/tree/master/src/test/scala/ru/tinkoff/gatling/kafka/examples)
+
+## Avro support in Request-Reply
+
+### Scala
+
+To use avro messages as payload in key or value, you must:
+
+- define implicit for schema registry url:
+
+```scala
+implicit val schemaRegUrl: String = "http://localhost:9094"
+```
+
+- or define serde for your class:
+
+```scala
+val ser =
+  new KafkaAvroSerializer(
+    new CachedSchemaRegistryClient("schRegUrl".split(',').toList.asJava, 16),
+  )
+
+val de =
+  new KafkaAvroDeserializer(
+    new CachedSchemaRegistryClient("schRegUrl".split(',').toList.asJava, 16),
+  )
+
+implicit val serdeClass: Serde[AvroClass] = new Serde[AvroClass] {
+  override def serializer(): Serializer[AvroClass] = ser.asInstanceOf[Serializer[AvroClass]]
+  override def deserializer(): Deserializer[AvroClass] = de.asInstanceOf[Deserializer[AvroClass]]
+}
+```
+
+### Java
+
+To use avro messages as payload in key or value, you must define serde for your class:
+
+```java
+public static Serializer<AvroClass> ser = (Serializer) new KafkaAvroSerializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
+public static Deserializer<AvroClass> de = (Deserializer) new KafkaAvroDeserializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
+```
+
+### Kotlin
+
+To use avro messages as payload in key or value, you must define serde for your class:
+
+```kotlin
+    val ser = KafkaAvroSerializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Serializer<AvroClass>
+val de = KafkaAvroDeserializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Deserializer<AvroClass>
+```
+
+### Example usage Avro in Request-Reply
+
+Example [scala](src/test/scala/ru/tinkoff/gatling/kafka/examples/AvroClassWithRequestReplySimulation.scala)
+
+Example [java](src/test/java/ru/tinkoff/gatling/kafka/examples/AvroClassWithRequestReplySimulation.java)
+
+Example [kotlin](src/test/kotlin/ru/tinkoff/gatling/kafka/examples/AvroClassWithRequestReplySimulation.kt)

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ val de =
     new CachedSchemaRegistryClient("schRegUrl".split(',').toList.asJava, 16),
   )
 
-implicit val serdeClass: Serde[AvroClass] = new Serde[AvroClass] {
-  override def serializer(): Serializer[AvroClass] = ser.asInstanceOf[Serializer[AvroClass]]
-  override def deserializer(): Deserializer[AvroClass] = de.asInstanceOf[Deserializer[AvroClass]]
+implicit val serdeClass: Serde[MyAvroClass] = new Serde[MyAvroClass] {
+  override def serializer(): Serializer[MyAvroClass] = ser.asInstanceOf[Serializer[MyAvroClass]]
+  override def deserializer(): Deserializer[MyAvroClass] = de.asInstanceOf[Deserializer[MyAvroClass]]
 }
 ```
 
@@ -104,8 +104,8 @@ implicit val serdeClass: Serde[AvroClass] = new Serde[AvroClass] {
 To use avro messages as payload in key or value, you must define serde for your class:
 
 ```java
-public static Serializer<AvroClass> ser = (Serializer) new KafkaAvroSerializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
-public static Deserializer<AvroClass> de = (Deserializer) new KafkaAvroDeserializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
+public static Serializer<MyAvroClass> ser = (Serializer) new KafkaAvroSerializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
+public static Deserializer<MyAvroClass> de = (Deserializer) new KafkaAvroDeserializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
 ```
 
 ### Kotlin
@@ -113,8 +113,8 @@ public static Deserializer<AvroClass> de = (Deserializer) new KafkaAvroDeseriali
 To use avro messages as payload in key or value, you must define serde for your class:
 
 ```kotlin
-val ser = KafkaAvroSerializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Serializer<AvroClass>
-val de = KafkaAvroDeserializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Deserializer<AvroClass>
+val ser = KafkaAvroSerializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Serializer<MyAvroClass>
+val de = KafkaAvroDeserializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Deserializer<MyAvroClass>
 ```
 
 ### Example usage Avro in Request-Reply

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
   private object Versions {
-    // TODO: 7.3.1-ce (kafka 3.3) throw exception on test startup https://issues.apache.org/jira/browse/KAFKA-14270, will be fixed in kafka 3.4
-    val kafka   = "3.4.0"
+    // TODO: 7.3.x (kafka 3.3) throw exception on test startup https://issues.apache.org/jira/browse/KAFKA-14270, fixed in kafka 3.4 (waiting confluent release 7.4.x)
+    val kafka   = "7.3.3-ce"
     val gatling = "3.9.0"
     val avro4s  = "4.1.0"
     val avro    = "1.11.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
   lazy val avroCompiler: ModuleID = "org.apache.avro" % "avro-compiler" % Versions.avro
   lazy val avroCore: ModuleID     = "org.apache.avro" % "avro"          % Versions.avro
   lazy val avroSerdes: ModuleID   =
-    ("io.confluent" % "kafka-streams-avro-serde" % "3.4.0").exclude("org.apache.kafka", "kafka-streams-scala")
-  lazy val avroSerializers: ModuleID = "io.confluent" % "kafka-avro-serializer" % "3.4.0"
+    ("io.confluent" % "kafka-streams-avro-serde" % "7.3.3").exclude("org.apache.kafka", "kafka-streams-scala")
+  lazy val avroSerializers: ModuleID = "io.confluent" % "kafka-avro-serializer" % "7.3.3"
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   private object Versions {
     // TODO: 7.3.1-ce (kafka 3.3) throw exception on test startup https://issues.apache.org/jira/browse/KAFKA-14270, will be fixed in kafka 3.4
-    val kafka   = "7.3.0-ce"
+    val kafka   = "7.3.3-ce"
     val gatling = "3.9.0"
     val avro4s  = "4.1.0"
     val avro    = "1.11.1"
@@ -31,7 +31,7 @@ object Dependencies {
   lazy val avroCompiler: ModuleID = "org.apache.avro" % "avro-compiler" % Versions.avro
   lazy val avroCore: ModuleID     = "org.apache.avro" % "avro"          % Versions.avro
   lazy val avroSerdes: ModuleID   =
-    ("io.confluent" % "kafka-streams-avro-serde" % "7.3.0").exclude("org.apache.kafka", "kafka-streams-scala")
-  lazy val avroSerializers: ModuleID = "io.confluent" % "kafka-avro-serializer" % "7.3.0"
+    ("io.confluent" % "kafka-streams-avro-serde" % "7.3.3").exclude("org.apache.kafka", "kafka-streams-scala")
+  lazy val avroSerializers: ModuleID = "io.confluent" % "kafka-avro-serializer" % "7.3.3"
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   private object Versions {
     // TODO: 7.3.1-ce (kafka 3.3) throw exception on test startup https://issues.apache.org/jira/browse/KAFKA-14270, will be fixed in kafka 3.4
-    val kafka   = "7.3.3-ce"
+    val kafka   = "3.4.0"
     val gatling = "3.9.0"
     val avro4s  = "4.1.0"
     val avro    = "1.11.1"
@@ -31,7 +31,7 @@ object Dependencies {
   lazy val avroCompiler: ModuleID = "org.apache.avro" % "avro-compiler" % Versions.avro
   lazy val avroCore: ModuleID     = "org.apache.avro" % "avro"          % Versions.avro
   lazy val avroSerdes: ModuleID   =
-    ("io.confluent" % "kafka-streams-avro-serde" % "7.3.3").exclude("org.apache.kafka", "kafka-streams-scala")
-  lazy val avroSerializers: ModuleID = "io.confluent" % "kafka-avro-serializer" % "7.3.3"
+    ("io.confluent" % "kafka-streams-avro-serde" % "3.4.0").exclude("org.apache.kafka", "kafka-streams-scala")
+  lazy val avroSerializers: ModuleID = "io.confluent" % "kafka-avro-serializer" % "3.4.0"
 
 }

--- a/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
@@ -44,7 +44,7 @@ class TrackersPool(
         builder.stream[Array[Byte], Array[Byte]](outputTopic).foreach { case (k, v) =>
           val message = KafkaProtocolMessage(k, v, inputTopic, outputTopic)
           if (messageMatcher.responseMatch(message) == null) {
-            logger.error(s"no messageMatcher key for read message")
+            logger.error(s"no messageMatcher key for read message ${message} in inputTopic ${inputTopic}, outputTopic ${outputTopic}")
           } else {
             if (k == null || v == null)
               logger.info(s" --- received message with null key or value")

--- a/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
@@ -45,7 +45,7 @@ class TrackersPool(
           val message = KafkaProtocolMessage(k, v, inputTopic, outputTopic)
           if (messageMatcher.responseMatch(message) == null) {
             logger.error(
-              s"no messageMatcher key for read message in inputTopic ${inputTopic}, outputTopic ${outputTopic}",
+              s"no messageMatcher key for read message ${message} in inputTopic ${inputTopic}, outputTopic ${outputTopic}",
             )
           } else {
             if (k == null || v == null)

--- a/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
@@ -45,7 +45,7 @@ class TrackersPool(
           val message = KafkaProtocolMessage(k, v, inputTopic, outputTopic)
           if (messageMatcher.responseMatch(message) == null) {
             logger.error(
-              s"no messageMatcher key for read message ${message} in inputTopic ${inputTopic}, outputTopic ${outputTopic}",
+              s"no messageMatcher key for read message in inputTopic ${inputTopic}, outputTopic ${outputTopic}",
             )
           } else {
             if (k == null || v == null)

--- a/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
@@ -44,7 +44,9 @@ class TrackersPool(
         builder.stream[Array[Byte], Array[Byte]](outputTopic).foreach { case (k, v) =>
           val message = KafkaProtocolMessage(k, v, inputTopic, outputTopic)
           if (messageMatcher.responseMatch(message) == null) {
-            logger.error(s"no messageMatcher key for read message ${message} in inputTopic ${inputTopic}, outputTopic ${outputTopic}")
+            logger.error(
+              s"no messageMatcher key for read message ${message} in inputTopic ${inputTopic}, outputTopic ${outputTopic}",
+            )
           } else {
             if (k == null || v == null)
               logger.info(s" --- received message with null key or value")

--- a/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/ru/tinkoff/gatling/kafka/client/TrackersPool.scala
@@ -44,9 +44,7 @@ class TrackersPool(
         builder.stream[Array[Byte], Array[Byte]](outputTopic).foreach { case (k, v) =>
           val message = KafkaProtocolMessage(k, v, inputTopic, outputTopic)
           if (messageMatcher.responseMatch(message) == null) {
-            logger.error(
-              s"no messageMatcher key for read message ${message} in inputTopic ${inputTopic}, outputTopic ${outputTopic}",
-            )
+            logger.error(s"no messageMatcher key for read message")
           } else {
             if (k == null || v == null)
               logger.info(s" --- received message with null key or value")

--- a/src/main/scala/ru/tinkoff/gatling/kafka/request/KafkaSerdesImplicits.scala
+++ b/src/main/scala/ru/tinkoff/gatling/kafka/request/KafkaSerdesImplicits.scala
@@ -34,11 +34,11 @@ trait KafkaSerdesImplicits {
 
   implicit def serdeClass[T](implicit schemaRegUrl: String): Serde[T] = new Serde[T] {
     override def serializer(): Serializer[T] = new KafkaAvroSerializer(
-      new CachedSchemaRegistryClient(schemaRegUrl.split(',').toList.asJava, 16)
+      new CachedSchemaRegistryClient(schemaRegUrl.split(',').toList.asJava, 16),
     ).asInstanceOf[Serializer[T]]
 
     override def deserializer(): Deserializer[T] = new KafkaAvroDeserializer(
-      new CachedSchemaRegistryClient(schemaRegUrl.split(',').toList.asJava, 16)
+      new CachedSchemaRegistryClient(schemaRegUrl.split(',').toList.asJava, 16),
     ).asInstanceOf[Deserializer[T]]
   }
 

--- a/src/main/scala/ru/tinkoff/gatling/kafka/request/KafkaSerdesImplicits.scala
+++ b/src/main/scala/ru/tinkoff/gatling/kafka/request/KafkaSerdesImplicits.scala
@@ -1,12 +1,16 @@
 package ru.tinkoff.gatling.kafka.request
 
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import io.confluent.kafka.serializers.{KafkaAvroDeserializer, KafkaAvroSerializer}
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde
 import org.apache.avro.generic.GenericRecord
-import org.apache.kafka.common.serialization.{Serde, Serdes => JSerdes}
+import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer, Serdes => JSerdes}
 import org.apache.kafka.streams.kstream.WindowedSerdes
 
 import java.nio.ByteBuffer
 import java.util.UUID
+
+import scala.jdk.CollectionConverters._
 
 trait KafkaSerdesImplicits {
   implicit def stringSerde: Serde[String]                             = JSerdes.String()
@@ -28,5 +32,16 @@ trait KafkaSerdesImplicits {
   implicit def sessionWindowedSerde[T](implicit tSerde: Serde[T]): WindowedSerdes.SessionWindowedSerde[T] =
     new WindowedSerdes.SessionWindowedSerde[T](tSerde)
 
+  implicit def serdeClass[T](implicit schemaRegUrl: String): Serde[T] = new Serde[T] {
+    override def serializer(): Serializer[T] = new KafkaAvroSerializer(
+      new CachedSchemaRegistryClient(schemaRegUrl.split(',').toList.asJava, 16)
+    ).asInstanceOf[Serializer[T]]
+
+    override def deserializer(): Deserializer[T] = new KafkaAvroDeserializer(
+      new CachedSchemaRegistryClient(schemaRegUrl.split(',').toList.asJava, 16)
+    ).asInstanceOf[Deserializer[T]]
+  }
+
   implicit val avroSerde: Serde[GenericRecord] = new GenericAvroSerde()
+
 }

--- a/src/test/java/ru/tinkoff/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.java
+++ b/src/test/java/ru/tinkoff/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.java
@@ -17,9 +17,9 @@ import static ru.tinkoff.gatling.kafka.javaapi.KafkaDsl.kafka;
 public class AvroClassWithRequestReplySimulation extends Simulation {
 
     // example of using custom serde
-    public static Serializer<AvroClass> ser =
+    public static Serializer<MyAvroClass> ser =
             (Serializer) new KafkaAvroSerializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
-    public static Deserializer<AvroClass> de =
+    public static Deserializer<MyAvroClass> de =
             (Deserializer) new KafkaAvroDeserializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
 
     // protocol
@@ -43,13 +43,13 @@ public class AvroClassWithRequestReplySimulation extends Simulation {
     public static RequestReplyBuilder<?, ?> kafkaMessage = kafka("RequestReply").requestReply()
             .requestTopic("request.t")
             .replyTopic("reply.t")
-            .send("key", new AvroClass(), String.class, AvroClass.class, ser, de);
+            .send("key", new MyAvroClass(), String.class, MyAvroClass.class, ser, de);
 
     // simulation
     {
         setUp(scenario("Kafka RequestReply Avro").exec(kafkaMessage).injectOpen(atOnceUsers(1))).protocols(kafkaProtocolRRAvro);
     }
 
-    private static class AvroClass {
+    private static class MyAvroClass {
     }
 }

--- a/src/test/java/ru/tinkoff/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.java
+++ b/src/test/java/ru/tinkoff/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.java
@@ -1,0 +1,55 @@
+package ru.tinkoff.gatling.kafka.javaapi.examples;
+
+import io.gatling.javaapi.core.*;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import ru.tinkoff.gatling.kafka.javaapi.protocol.KafkaProtocolBuilderNew;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.serializers.*;
+import org.apache.kafka.common.serialization.*;
+import ru.tinkoff.gatling.kafka.javaapi.request.builder.RequestReplyBuilder;
+
+import java.time.Duration;
+import java.util.*;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static ru.tinkoff.gatling.kafka.javaapi.KafkaDsl.kafka;
+
+public class AvroClassWithRequestReplySimulation extends Simulation {
+
+    // example of using custom serde
+    public static Serializer<AvroClass> ser =
+            (Serializer) new KafkaAvroSerializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
+    public static Deserializer<AvroClass> de =
+            (Deserializer) new KafkaAvroDeserializer(new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16));
+
+    // protocol
+    private final KafkaProtocolBuilderNew kafkaProtocolRRAvro = kafka().requestReply()
+            .producerSettings(
+                    Map.of(
+                            ProducerConfig.ACKS_CONFIG, "1",
+                            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9093",
+                            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer",
+                            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroSerializer",
+                            // schema registry url is required for KafkaAvroSerializer and KafkaAvroDeserializer
+                            "schema.registry.url", "http://localhost:9094"
+                    )
+            )
+            .consumeSettings(
+                    Map.of("bootstrap.servers", "localhost:9093")
+            )
+            .timeout(Duration.ofSeconds(5));
+
+    // message
+    public static RequestReplyBuilder<?, ?> kafkaMessage = kafka("RequestReply").requestReply()
+            .requestTopic("request.t")
+            .replyTopic("reply.t")
+            .send("key", new AvroClass(), String.class, AvroClass.class, ser, de);
+
+    // simulation
+    {
+        setUp(scenario("Kafka RequestReply Avro").exec(kafkaMessage).injectOpen(atOnceUsers(1))).protocols(kafkaProtocolRRAvro);
+    }
+
+    private static class AvroClass {
+    }
+}

--- a/src/test/kotlin/ru/tinkoff/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.kt
+++ b/src/test/kotlin/ru/tinkoff/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.kt
@@ -1,0 +1,48 @@
+package ru.tinkoff.gatling.kafka.javaapi.examples
+
+import io.gatling.javaapi.core.CoreDsl.*
+import io.gatling.javaapi.core.Simulation
+import org.apache.kafka.clients.producer.ProducerConfig
+import ru.tinkoff.gatling.kafka.javaapi.*
+import ru.tinkoff.gatling.kafka.javaapi.KafkaDsl.*
+import ru.tinkoff.gatling.kafka.request.*
+import java.time.Duration
+
+class AvroClassWithRequestReplySimulation : Simulation() {
+
+    // example of using custom serde
+    val ser = KafkaAvroSerializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Serializer<AvroClass>
+    val de = KafkaAvroDeserializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Deserializer<AvroClass>
+
+    // protocol
+    val kafkaProtocolRRAvro = kafka()
+        .requestReply()
+        .producerSettings(
+            mapOf<String, Any>(
+                ProducerConfig.ACKS_CONFIG to "1",
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:9092",
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to "org.apache.kafka.common.serialization.StringSerializer",
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to "io.confluent.kafka.serializers.KafkaAvroSerializer",
+                // schema registry url is required for KafkaAvroSerializer and KafkaAvroDeserializer
+                "schema.registry.url" to "url"
+            )
+        )
+        .consumeSettings(
+            mapOf<String, Any>(
+                "bootstrap.servers" to "localhost:9092"
+            )
+        )
+        .timeout(Duration.ofSeconds(5))
+
+    // message
+    val kafkaMessage = kafka("RequestReply").requestReply()
+        .requestTopic("request.t")
+        .replyTopic("reply.t")
+        .send("key", AvroClass(), String::class.java, AvroClass::class.java, ser, de)
+
+    // simulation
+    init {
+        setUp(scenario("Kafka scenario").exec(kafkaMessage).injectOpen(atOnceUsers(1))).protocols(kafkaProtocolRRAvro)
+    }
+
+}

--- a/src/test/kotlin/ru/tinkoff/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.kt
+++ b/src/test/kotlin/ru/tinkoff/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.kt
@@ -11,8 +11,8 @@ import java.time.Duration
 class AvroClassWithRequestReplySimulation : Simulation() {
 
     // example of using custom serde
-    val ser = KafkaAvroSerializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Serializer<AvroClass>
-    val de = KafkaAvroDeserializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Deserializer<AvroClass>
+    val ser = KafkaAvroSerializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Serializer<MyAvroClass>
+    val de = KafkaAvroDeserializer(CachedSchemaRegistryClient("schRegUrl".split(','), 16),) as Deserializer<MyAvroClass>
 
     // protocol
     val kafkaProtocolRRAvro = kafka()
@@ -38,7 +38,7 @@ class AvroClassWithRequestReplySimulation : Simulation() {
     val kafkaMessage = kafka("RequestReply").requestReply()
         .requestTopic("request.t")
         .replyTopic("reply.t")
-        .send("key", AvroClass(), String::class.java, AvroClass::class.java, ser, de)
+        .send("key", MyAvroClass(), String::class.java, MyAvroClass::class.java, ser, de)
 
     // simulation
     init {

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+        </encoder>
+        <immediateFlush>false</immediateFlush>
+    </appender>
+
+    <!-- uncomment and set to DEBUG to log all failing HTTP requests -->
+    <!-- uncomment and set to TRACE to log all HTTP requests -->
+    <!--<logger name="io.gatling.http.engine.response" level="TRACE" />-->
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/AvroClassWithRequestReplySimulation.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/AvroClassWithRequestReplySimulation.scala
@@ -1,0 +1,67 @@
+package ru.tinkoff.gatling.kafka.examples
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import io.confluent.kafka.serializers.{KafkaAvroDeserializer, KafkaAvroSerializer}
+import io.gatling.core.Predef._
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer}
+import ru.tinkoff.gatling.kafka.Predef._
+import ru.tinkoff.gatling.kafka.actions.KafkaRequestReplyActionBuilder
+import ru.tinkoff.gatling.kafka.protocol.KafkaProtocol
+
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
+
+class AvroClassWithRequestReplySimulation extends Simulation {
+
+  // default serde for unknown classes is avro serde
+  // schemaRegUrl must be specified if custom avro scheme is used, when the send method requires implicit
+  implicit val schemaRegUrl: String = "http://localhost:9094"
+
+  // example if you want to use your own or custom serde
+  val ser =
+    new KafkaAvroSerializer(
+      new CachedSchemaRegistryClient("schRegUrl".split(',').toList.asJava, 16),
+    )
+
+  val de =
+    new KafkaAvroDeserializer(
+      new CachedSchemaRegistryClient("schRegUrl".split(',').toList.asJava, 16),
+    )
+
+  implicit val serdeClass: Serde[AvroClass] = new Serde[AvroClass] {
+    override def serializer(): Serializer[AvroClass] = ser.asInstanceOf[Serializer[AvroClass]]
+
+    override def deserializer(): Deserializer[AvroClass] = de.asInstanceOf[Deserializer[AvroClass]]
+  }
+
+  // protocol
+  val kafkaProtocolRRAvro: KafkaProtocol = kafka.requestReply
+    .producerSettings(
+      Map(
+        ProducerConfig.ACKS_CONFIG -> "1",
+        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> "localhost:9093",
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.StringSerializer",
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "io.confluent.kafka.serializers.KafkaAvroSerializer",
+        // schema registry url is required for KafkaAvroSerializer and KafkaAvroDeserializer
+        "schema.registry.url" -> "http://localhost:9094",
+      ),
+    )
+    .consumeSettings(
+      Map(
+        "bootstrap.servers" -> "localhost:9093",
+      ),
+    )
+    .timeout(5.seconds)
+
+  // message
+  val kafkaMessage: KafkaRequestReplyActionBuilder[String, AvroClass] = kafka("RequestReply").requestReply
+    .requestTopic("request.t")
+    .replyTopic("reply.t")
+    .send[String, AvroClass]("key", AvroClass())
+
+  // simulation
+  setUp(scenario("Kafka RequestReply Avro").exec(kafkaMessage).inject(atOnceUsers(1))).protocols(kafkaProtocolRRAvro)
+
+  case class AvroClass()
+}

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/AvroClassWithRequestReplySimulation.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/AvroClassWithRequestReplySimulation.scala
@@ -29,10 +29,10 @@ class AvroClassWithRequestReplySimulation extends Simulation {
       new CachedSchemaRegistryClient("schRegUrl".split(',').toList.asJava, 16),
     )
 
-  implicit val serdeClass: Serde[AvroClass] = new Serde[AvroClass] {
-    override def serializer(): Serializer[AvroClass] = ser.asInstanceOf[Serializer[AvroClass]]
+  implicit val serdeClass: Serde[MyAvroClass] = new Serde[MyAvroClass] {
+    override def serializer(): Serializer[MyAvroClass] = ser.asInstanceOf[Serializer[MyAvroClass]]
 
-    override def deserializer(): Deserializer[AvroClass] = de.asInstanceOf[Deserializer[AvroClass]]
+    override def deserializer(): Deserializer[MyAvroClass] = de.asInstanceOf[Deserializer[MyAvroClass]]
   }
 
   // protocol
@@ -55,13 +55,13 @@ class AvroClassWithRequestReplySimulation extends Simulation {
     .timeout(5.seconds)
 
   // message
-  val kafkaMessage: KafkaRequestReplyActionBuilder[String, AvroClass] = kafka("RequestReply").requestReply
+  val kafkaMessage: KafkaRequestReplyActionBuilder[String, MyAvroClass] = kafka("RequestReply").requestReply
     .requestTopic("request.t")
     .replyTopic("reply.t")
-    .send[String, AvroClass]("key", AvroClass())
+    .send[String, MyAvroClass]("key", MyAvroClass())
 
   // simulation
   setUp(scenario("Kafka RequestReply Avro").exec(kafkaMessage).inject(atOnceUsers(1))).protocols(kafkaProtocolRRAvro)
 
-  case class AvroClass()
+  case class MyAvroClass()
 }

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/AvroClassWithRequestReplySimulation.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/AvroClassWithRequestReplySimulation.scala
@@ -39,12 +39,12 @@ class AvroClassWithRequestReplySimulation extends Simulation {
   val kafkaProtocolRRAvro: KafkaProtocol = kafka.requestReply
     .producerSettings(
       Map(
-        ProducerConfig.ACKS_CONFIG -> "1",
-        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> "localhost:9093",
-        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.StringSerializer",
+        ProducerConfig.ACKS_CONFIG                   -> "1",
+        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> "localhost:9093",
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> "org.apache.kafka.common.serialization.StringSerializer",
         ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "io.confluent.kafka.serializers.KafkaAvroSerializer",
         // schema registry url is required for KafkaAvroSerializer and KafkaAvroDeserializer
-        "schema.registry.url" -> "http://localhost:9094",
+        "schema.registry.url"                        -> "http://localhost:9094",
       ),
     )
     .consumeSettings(

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -88,7 +88,7 @@ class KafkaGatlingTest extends Simulation {
         "bootstrap.servers" -> "localhost:9093",
       ),
     )
-    .timeout(7.seconds)
+    .timeout(10.seconds)
     .matchByValue
 
   val kafkaAvro4sConf: KafkaProtocol = kafka
@@ -157,7 +157,7 @@ class KafkaGatlingTest extends Simulation {
         .requestTopic("myTopic2")
         .replyTopic("test.t2")
         .send[Array[Byte], Array[Byte]]("test".getBytes(), "tstBytes".getBytes())
-        .check(bodyBytes.is("tstBytes".getBytes())),
+        .check(bodyBytes.is("tstBytes".getBytes()).saveAs("bodyInfo")),
     )
 
   val scnAvro4s: ScenarioBuilder = scenario("Request Avro4s")
@@ -173,19 +173,19 @@ class KafkaGatlingTest extends Simulation {
   val scnRRwo: ScenarioBuilder = scenario("RequestReply w/o answer")
     .exec(
       kafka("Request Reply Bytes wo").requestReply
-        .requestTopic("myTopic3")
-        .replyTopic("test.t3")
+        .requestTopic("myTopic2")
+        .replyTopic("test.t2")
         .send[Array[Byte], Array[Byte]]("testWO".getBytes(), "tstBytesWO".getBytes()),
     )
 
   setUp(
     scnRR.inject(atOnceUsers(1)).protocols(kafkaProtocolRRString),
     scn.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConf),
-    scnRR2.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaProtocolRRBytes),
-    scn2.inject(nothingFor(4), atOnceUsers(1)).protocols(kafkaConfBytes),
+    scnRR2.inject(atOnceUsers(1)).protocols(kafkaProtocolRRBytes),
+    scn2.inject(nothingFor(5), atOnceUsers(1)).protocols(kafkaConfBytes),
     scnAvro4s.inject(atOnceUsers(1)).protocols(kafkaAvro4sConf),
     scnRRwo.inject(atOnceUsers(1)).protocols(kafkaProtocolRRBytes),
-    scnwokey.inject(nothingFor(3), atOnceUsers(1)).protocols(kafkaConfwoKey),
+    scnwokey.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConfwoKey),
   ).assertions(
     global.failedRequests.percent.lt(15.0),
   )

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -36,6 +36,17 @@ class KafkaGatlingTest extends Simulation {
       ),
     )
 
+  val kafkaConfwoKey: KafkaProtocol = kafka
+    .topic("myTopic3")
+    .properties(
+      Map(
+        ProducerConfig.ACKS_CONFIG                   -> "1",
+        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> "localhost:9093",
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> "org.apache.kafka.common.serialization.StringSerializer",
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.StringSerializer",
+      ),
+    )
+
   val kafkaConfBytes: KafkaProtocol = kafka
     .topic("test.t2")
     .properties(
@@ -125,11 +136,13 @@ class KafkaGatlingTest extends Simulation {
         .check(jsonPath("$.m").is("dkf")),
     )
 
-  val scn: ScenarioBuilder = scenario("Request String")
+  val scnwokey: ScenarioBuilder = scenario("Request String")
     .exec(
       kafka("Request String")
         .send[String]("foo"),
     )
+
+  val scn: ScenarioBuilder = scenario("Request String")
     .exec(kafka("Request String 2").send[String, String]("testCheckJson", """{ "m": "dkf" }"""))
 
   val scn2: ScenarioBuilder = scenario("Request Byte")
@@ -171,6 +184,7 @@ class KafkaGatlingTest extends Simulation {
     scn2.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConfBytes),
     scnAvro4s.inject(atOnceUsers(1)).protocols(kafkaAvro4sConf),
     scnRRwo.inject(atOnceUsers(1)).protocols(kafkaProtocolRRBytes),
+    scnwokey.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConfwoKey),
   ).assertions(
     global.failedRequests.percent.lt(15.0),
   )

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -156,7 +156,8 @@ class KafkaGatlingTest extends Simulation {
       kafka("Request Reply Bytes").requestReply
         .requestTopic("myTopic2")
         .replyTopic("test.t2")
-        .send[Array[Byte], Array[Byte]]("test".getBytes(), "tstBytes".getBytes()),
+        .send[Array[Byte], Array[Byte]]("test".getBytes(), "tstBytes".getBytes())
+        .check(bodyBytes.is("tstBytes".getBytes())),
     )
 
   val scnAvro4s: ScenarioBuilder = scenario("Request Avro4s")
@@ -171,7 +172,7 @@ class KafkaGatlingTest extends Simulation {
 
   val scnRRwo: ScenarioBuilder = scenario("RequestReply w/o answer")
     .exec(
-      kafka("Request Reply Bytes").requestReply
+      kafka("Request Reply Bytes wo").requestReply
         .requestTopic("myTopic3")
         .replyTopic("test.t3")
         .send[Array[Byte], Array[Byte]]("testWO".getBytes(), "tstBytesWO".getBytes()),
@@ -180,11 +181,11 @@ class KafkaGatlingTest extends Simulation {
   setUp(
     scnRR.inject(atOnceUsers(1)).protocols(kafkaProtocolRRString),
     scn.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConf),
-    scnRR2.inject(atOnceUsers(1)).protocols(kafkaProtocolRRBytes),
-    scn2.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConfBytes),
+    scnRR2.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaProtocolRRBytes),
+    scn2.inject(nothingFor(4), atOnceUsers(1)).protocols(kafkaConfBytes),
     scnAvro4s.inject(atOnceUsers(1)).protocols(kafkaAvro4sConf),
     scnRRwo.inject(atOnceUsers(1)).protocols(kafkaProtocolRRBytes),
-    scnwokey.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConfwoKey),
+    scnwokey.inject(nothingFor(3), atOnceUsers(1)).protocols(kafkaConfwoKey),
   ).assertions(
     global.failedRequests.percent.lt(15.0),
   )

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -94,9 +94,9 @@ class KafkaGatlingTest extends Simulation {
   val kafkaProtocolRRBytes2: KafkaProtocol = kafka.requestReply
     .producerSettings(
       Map(
-        ProducerConfig.ACKS_CONFIG -> "1",
-        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> "localhost:9093",
-        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.ByteArraySerializer",
+        ProducerConfig.ACKS_CONFIG                   -> "1",
+        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> "localhost:9093",
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> "org.apache.kafka.common.serialization.ByteArraySerializer",
         ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.ByteArraySerializer",
       ),
     )

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -136,7 +136,7 @@ class KafkaGatlingTest extends Simulation {
         .check(jsonPath("$.m").is("dkf")),
     )
 
-  val scnwokey: ScenarioBuilder = scenario("Request String")
+  val scnwokey: ScenarioBuilder = scenario("Request String without key")
     .exec(
       kafka("Request String")
         .send[String]("foo"),

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -88,7 +88,24 @@ class KafkaGatlingTest extends Simulation {
         "bootstrap.servers" -> "localhost:9093",
       ),
     )
-    .timeout(10.seconds)
+    .timeout(5.seconds)
+    .matchByValue
+
+  val kafkaProtocolRRBytes2: KafkaProtocol = kafka.requestReply
+    .producerSettings(
+      Map(
+        ProducerConfig.ACKS_CONFIG -> "1",
+        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> "localhost:9093",
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.ByteArraySerializer",
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.ByteArraySerializer",
+      ),
+    )
+    .consumeSettings(
+      Map(
+        "bootstrap.servers" -> "localhost:9093",
+      ),
+    )
+    .timeout(1.seconds)
     .matchByValue
 
   val kafkaAvro4sConf: KafkaProtocol = kafka
@@ -182,9 +199,9 @@ class KafkaGatlingTest extends Simulation {
     scnRR.inject(atOnceUsers(1)).protocols(kafkaProtocolRRString),
     scn.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConf),
     scnRR2.inject(atOnceUsers(1)).protocols(kafkaProtocolRRBytes),
-    scn2.inject(nothingFor(5), atOnceUsers(1)).protocols(kafkaConfBytes),
+    scn2.inject(nothingFor(2), atOnceUsers(1)).protocols(kafkaConfBytes),
     scnAvro4s.inject(atOnceUsers(1)).protocols(kafkaAvro4sConf),
-    scnRRwo.inject(atOnceUsers(1)).protocols(kafkaProtocolRRBytes),
+    scnRRwo.inject(atOnceUsers(1)).protocols(kafkaProtocolRRBytes2),
     scnwokey.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConfwoKey),
   ).assertions(
     global.failedRequests.percent.lt(15.0),

--- a/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/ru/tinkoff/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -26,7 +26,7 @@ class KafkaGatlingTest extends Simulation {
   implicit val ingredientHeaders: Headers                   = new RecordHeaders()
 
   val kafkaConf: KafkaProtocol = kafka
-    .topic("test.t")
+    .topic("test.t1")
     .properties(
       Map(
         ProducerConfig.ACKS_CONFIG                   -> "1",
@@ -37,7 +37,7 @@ class KafkaGatlingTest extends Simulation {
     )
 
   val kafkaConfBytes: KafkaProtocol = kafka
-    .topic("test.t")
+    .topic("test.t2")
     .properties(
       Map(
         ProducerConfig.ACKS_CONFIG                   -> "1",
@@ -77,11 +77,11 @@ class KafkaGatlingTest extends Simulation {
         "bootstrap.servers" -> "localhost:9093",
       ),
     )
-    .timeout(5.seconds)
+    .timeout(7.seconds)
     .matchByValue
 
   val kafkaAvro4sConf: KafkaProtocol = kafka
-    .topic("test.t")
+    .topic("test.t3")
     .properties(
       Map(
         ProducerConfig.ACKS_CONFIG                   -> "1",
@@ -113,14 +113,14 @@ class KafkaGatlingTest extends Simulation {
         "bootstrap.servers" -> "localhost:9093",
       ),
     )
-    .timeout(5.seconds)
+    .timeout(7.seconds)
     .matchByMessage(matchByOwnVal)
 
   val scnRR: ScenarioBuilder = scenario("RequestReply String")
     .exec(
       kafka("Request Reply String").requestReply
-        .requestTopic("myTopic")
-        .replyTopic("test.t")
+        .requestTopic("myTopic1")
+        .replyTopic("test.t1")
         .send[String, String]("testCheckJson", """{ "m": "dkf" }""")
         .check(jsonPath("$.m").is("dkf")),
     )
@@ -141,8 +141,8 @@ class KafkaGatlingTest extends Simulation {
   val scnRR2: ScenarioBuilder = scenario("RequestReply Bytes")
     .exec(
       kafka("Request Reply Bytes").requestReply
-        .requestTopic("myTopic")
-        .replyTopic("test.t")
+        .requestTopic("myTopic2")
+        .replyTopic("test.t2")
         .send[Array[Byte], Array[Byte]]("test".getBytes(), "tstBytes".getBytes()),
     )
 
@@ -159,8 +159,8 @@ class KafkaGatlingTest extends Simulation {
   val scnRRwo: ScenarioBuilder = scenario("RequestReply w/o answer")
     .exec(
       kafka("Request Reply Bytes").requestReply
-        .requestTopic("myTopic")
-        .replyTopic("test.t")
+        .requestTopic("myTopic3")
+        .replyTopic("test.t3")
         .send[Array[Byte], Array[Byte]]("testWO".getBytes(), "tstBytesWO".getBytes()),
     )
 


### PR DESCRIPTION
Features:
- added implicit (Scala only supports) for unknown classes in request reply
- added docs in readme and examples for avro usage in request reply

Fix:
- fix request reply timeout and trackerpool errors and increase coverage
- added logback.xml for clear output in test